### PR TITLE
Marking ports as broken

### DIFF
--- a/bucket_85/xorg-driver-input-mouse/specification
+++ b/bucket_85/xorg-driver-input-mouse/specification
@@ -26,8 +26,6 @@ LICENSE_SCHEME=		solo
 
 FPC_EQUIVALENT=		x11-drivers/${ALTNAME}
 
-BROKEN[linux]=		Wants to link against non-existing libusbhid
-
 BUILDRUN_DEPENDS=	xorg-server:single:standard
 
 USES=			libtool

--- a/bucket_85/xorg-driver-input-mouse/specification
+++ b/bucket_85/xorg-driver-input-mouse/specification
@@ -26,6 +26,8 @@ LICENSE_SCHEME=		solo
 
 FPC_EQUIVALENT=		x11-drivers/${ALTNAME}
 
+BROKEN[linux]=		Wants to link against non-existing libusbhid
+
 BUILDRUN_DEPENDS=	xorg-server:single:standard
 
 USES=			libtool

--- a/bucket_A8/ede/specification
+++ b/bucket_A8/ede/specification
@@ -43,9 +43,9 @@ MUST_CONFIGURE=		gnu
 
 post-patch:
 	${REINPLACE_CMD} -e "s|__LDFLAGS__|${LDFLAGS}|" \
-		${WRKSRC}/build/Program.jam
-	${REINPLACE_CMD} -e "s|__LDFLAGS__|${LDFLAGS}|" ${WRKSRC}/evoke/Jamfile
-	${REINPLACE_CMD} -e "s|__LDFLAGS__|${LDFLAGS}|" ${WRKSRC}/pekwm/Jamfile
+		${WRKSRC}/build/Program.jam \
+		${WRKSRC}/evoke/Jamfile \
+		${WRKSRC}/pekwm/Jamfile
 
 do-build:
 	(cd ${WRKSRC} && ${SETENV} ${MAKE_ENV} jam)

--- a/bucket_B6/gts/specification
+++ b/bucket_B6/gts/specification
@@ -20,9 +20,7 @@ OPTIONS_STANDARD=	none
 
 FPC_EQUIVALENT=		graphics/gts
 
-BROKEN[freebsd]=	Configure script detects that ld is incapable of shared library support
-
-USES=			libtool pkgconfig
+USES=			libtool pkgconfig fbsd10fix
 GNOME_COMPONENTS=	glib
 INSTALL_TARGET=		install-strip
 MUST_CONFIGURE=		gnu

--- a/bucket_B6/gts/specification
+++ b/bucket_B6/gts/specification
@@ -20,6 +20,8 @@ OPTIONS_STANDARD=	none
 
 FPC_EQUIVALENT=		graphics/gts
 
+BROKEN[freebsd]=	Configure script detects that ld is incapable of shared library support
+
 USES=			libtool pkgconfig
 GNOME_COMPONENTS=	glib
 INSTALL_TARGET=		install-strip


### PR DESCRIPTION
Marking two ports broken that I have no idea on how to fix:

gts fails to build on fbsd. Log file contains this suspicious line:

`checking whether the c++ linker (/raven/toolchain/bin/ld) supports shared libraries... no`

Debugging the Ravenports toolchain is way above my head unfortunately...

xorg-driver-input-mouse cannot be built on Linux. Here's what goes wrong:

`/raven/toolchain/bin/ld: cannot find -lusbhid`

I did some reading on this one. Looks like libusbhid doesn't exist on Linux systems. I have no idea why Ravenports wants to link the driver against it, though.

----

You've probably overlooked my question regarding reporting of broken ports. Is this kind of "reporting" (adding the BROKEN keyword and issuing a pull request) how you would like things to go? Or would opening an issue here on GH preferable?

BTW: I've set up a Linux machine to do some tests. Since the mouse driver cannot be used I haven't been able to test X11 so far. I tried to work around it by creating packages for:

- libevdev
- libmtdev
- xorg-driver-input-evdev

The driver and both dependencies build on fbsd, but the driver seems not to be usable. The FreeBSD port pulls in webcamd and I guess that it's needed to make the input driver work on that platform. Looks like a lot more work, though (depends on cuse4bsd-kmod which requires kernel sources) and more adventure than I would like for now. On Linux it seems to be fairly popular these days (which is why I tried to port it in the first place). However while the libevdev and libmtdev ports build on fbsd, they both fail on Linux (error: conflicting types for '__u64'). Just out of curiosity: Are you interested in the evdev input driver at all?

And here's a little offhand proposal: How about a special "bucket_scretch" or something to collect unfinished ports that cannot be part of Conspiracy for now but might inspire somebody else to pick up what's already done and finish it? That way half-way-done ports could be preserved until work resumes and if somebody else thinks of porting it in the meanwhile the work that was already done doesn't need to be done again.