### PR TITLE
Resolve symbol conflict when building mpc against mpfr 4.0.0

### DIFF
--- a/bucket_A0/mpc/patches/patch-configure.ac
+++ b/bucket_A0/mpc/patches/patch-configure.ac
@@ -1,0 +1,25 @@
+--- configure.ac.orig	2017-12-30 22:07:09.254522000 +0100
++++ configure.ac	2017-12-30 22:09:03.981991000 +0100
+@@ -165,6 +165,22 @@
+         AC_MSG_ERROR([libmpfr not found or uses a different ABI (including static vs shared).])
+         ])
+ 
++AC_MSG_CHECKING(for mpfr_fmma)
++LIBS="-lmpfr $LIBS"
++AC_LINK_IFELSE(
++	[AC_LANG_PROGRAM(
++		[[#include "mpfr.h"]],
++		[[mpfr_t x; mpfr_fmma (x, x, x, x, x, 0);]]
++	)],
++	[
++	AC_MSG_RESULT(yes)
++	AC_DEFINE(HAVE_MPFR_FMMA, 1, [mpfr_fmma is present])
++	],
++	[
++	AC_MSG_RESULT(no)
++	AC_DEFINE(HAVE_MPFR_FMMA, 0, [mpfr_fmma is not present])
++	])
++
+ # Check for a recent GMP
+ # We only guarantee that with a *functional* and recent enough GMP version,
+ # MPC will compile; we do not guarantee that GMP will compile.

--- a/bucket_A0/mpc/patches/patch-src_mul.c
+++ b/bucket_A0/mpc/patches/patch-src_mul.c
@@ -1,0 +1,43 @@
+--- src/mul.c.orig	2017-12-30 22:11:00.188369000 +0100
++++ src/mul.c	2017-12-30 22:17:31.900188000 +0100
+@@ -170,9 +170,9 @@
+    return MPC_INEX (inex_re, inex_im);
+ }
+ 
+-
++#if HAVE_MPFR_FMMA == 0
+ static int
+-mpfr_fmma (mpfr_ptr z, mpfr_srcptr a, mpfr_srcptr b, mpfr_srcptr c,
++mpc_fmma (mpfr_ptr z, mpfr_srcptr a, mpfr_srcptr b, mpfr_srcptr c,
+            mpfr_srcptr d, int sign, mpfr_rnd_t rnd)
+ {
+    /* Computes z = ab+cd if sign >= 0, or z = ab-cd if sign < 0.
+@@ -319,7 +319,7 @@
+ 
+    return inex;
+ }
+-
++#endif
+ 
+ int
+ mpc_mul_naive (mpc_ptr z, mpc_srcptr x, mpc_srcptr y, mpc_rnd_t rnd)
+@@ -337,10 +337,17 @@
+    else
+       rop [0] = z [0];
+ 
+-   inex = MPC_INEX (mpfr_fmma (mpc_realref (rop), mpc_realref (x), mpc_realref (y), mpc_imagref (x),
+-                               mpc_imagref (y), -1, MPC_RND_RE (rnd)),
++#if HAVE_MPFR_FMMA
++   inex = MPC_INEX (mpfr_fmms (mpc_realref (rop), mpc_realref (x), mpc_realref (y), mpc_imagref (x),
++				mpc_imagref (y), MPC_RND_RE (rnd)),
+                     mpfr_fmma (mpc_imagref (rop), mpc_realref (x), mpc_imagref (y), mpc_imagref (x),
++				mpc_realref (y), MPC_RND_IM (rnd)));
++#else
++   inex = MPC_INEX (mpc_fmma (mpc_realref (rop), mpc_realref (x), mpc_realref (y), mpc_imagref (x),
++				mpc_imagref (y), -1, MPC_RND_RE (rnd)),
++		mpc_fmma (mpc_imagref (rop), mpc_realref (x), mpc_imagref (y), mpc_imagref (x),
+                                mpc_realref (y), +1, MPC_RND_IM (rnd)));
++#endif
+ 
+    mpc_set (z, rop, MPC_RNDNN);
+    if (overlap)

--- a/bucket_A0/mpc/specification
+++ b/bucket_A0/mpc/specification
@@ -3,6 +3,7 @@ DEF[PORTVERSION]=	1.0.3
 
 NAMEBASE=		mpc
 VERSION=		${PORTVERSION}
+REVISION=		1
 KEYWORDS=		math devel
 VARIANTS=		standard
 SDESC[standard]=	High-precision complex number library


### PR DESCRIPTION
Create patches from upstream changes that resolve the symbol conflict with mpfr 4.0.0 (#27).