### PR TITLE
Remove -DCMAKE_BUILD_TYPE from CMAKE_ARGS. Use CMAKE_BUILD_TYPE instead.

### DIFF
--- a/bucket_4A/llvm50/specification
+++ b/bucket_4A/llvm50/specification
@@ -53,9 +53,9 @@ SHEBANG_FILES=		tools/clang/tools/scan-view/bin/scan-view
 			tools/clang/tools/extra/include-fixer/find-all-symbols/tool/run-find-all-symbols.py
 CMAKE_INSTALL_PREFIX=	{{PREFIX}}/llvm${SUFFIX}
 CMAKE_ARGS=		-DLLVM_BUILD_LLVM_DYLIB=ON
-			-DCMAKE_BUILD_TYPE=Release
 			-DCMAKE_INSTALL_RPATH:STRING="{{LOCALBASE}}/llvm${SUFFIX}/lib"
 			-DLLVM_HOST_TRIPLE:STRING="{{CONFIGURE_TARGET}}"
+CMAKE_BUILD_TYPE=	Release
 PLIST_SUB=		NAMEBASE="llvm${SUFFIX}"
 			LLVM_RELEASE="${LLVM_VERSION}"
 			LLVM_MAJOR="${MAJOR}"

--- a/bucket_B9/llvm40/specification
+++ b/bucket_B9/llvm40/specification
@@ -54,10 +54,10 @@ SHEBANG_FILES=		tools/clang/tools/scan-view/bin/scan-view
 			tools/clang/tools/extra/include-fixer/find-all-symbols/tool/run-find-all-symbols.py
 CMAKE_INSTALL_PREFIX=	{{PREFIX}}/llvm${SUFFIX}
 CMAKE_ARGS=		-DLLVM_BUILD_LLVM_DYLIB=ON
-			-DCMAKE_BUILD_TYPE=Release
 			-DCMAKE_BUILD_WITH_INSTALL_RPATH=1
 			-DCMAKE_INSTALL_RPATH:STRING="{{LOCALBASE}}/llvm${SUFFIX}/lib"
 			-DLLVM_HOST_TRIPLE:STRING="{{CONFIGURE_TARGET}}"
+CMAKE_BUILD_TYPE=	Release
 PLIST_SUB=		NAMEBASE="llvm${SUFFIX}"
 			LLVM_RELEASE="${LLVM_VERSION}"
 			LLVM_MAJOR="${MAJOR}"


### PR DESCRIPTION
It gets overwritten by the standard CMAKE_BUILD_TYPE setting of
"USES=cmake" which is "Release". Changing it's value would have no
effect.