### PR TITLE
new port + trouble

### DIFF
--- a/bucket_5E/doas/descriptions/desc.single
+++ b/bucket_5E/doas/descriptions/desc.single
@@ -1,0 +1,3 @@
+The doas program allows users to run commands as another user (usually
+root). The doas program was written by the OpenBSD team to provide a
+lightweight, simplified (and more secure) alternative to the sudo command.

--- a/bucket_5E/doas/distinfo
+++ b/bucket_5E/doas/distinfo
@@ -1,0 +1,1 @@
+5afff34eaa4d9bf65ebe861f57056a97f9ea6ce61f6d3d1a25e69bcfadd33c46        18439 slicer69-doas-6.0p2.tar.gz

--- a/bucket_5E/doas/manifests/plist.single
+++ b/bucket_5E/doas/manifests/plist.single
@@ -1,0 +1,3 @@
+bin/doas
+share/man/man1/doas.1.gz
+share/man/man5/doas.conf.5.gz

--- a/bucket_5E/doas/specification
+++ b/bucket_5E/doas/specification
@@ -1,0 +1,43 @@
+DEF[PORTVERSION]=	6.0p2
+# ----------------------------------------------------------------------------
+
+NAMEBASE=		doas
+VERSION=		${PORTVERSION}
+KEYWORDS=		security
+VARIANTS=		standard
+SDESC[standard]=	Simple sudo alternative from OpenBSD
+HOMEPAGE=		none
+CONTACT=		Omar_Polo[omar.polo@europecom.net]
+
+DOWNLOAD_GROUPS=	main
+SITES[main]=		GITHUB/slicer69:doas:${PORTVERSION}
+DISTFILE[1]=		generated:main
+
+SPKGS[standard]=	single
+
+OPTIONS_AVAILABLE=	none
+OPTIONS_STANDARD=	none
+
+LICENSE=		BSD2CLAUSE:single
+LICENSE_SCHEME=		solo
+LICENSE_FILE=		BSD2CLAUSE:{{WRKDIR}}/LICENSE
+
+FPC_EQUIVALENT=		security/doas
+
+USES=			gmake
+
+BUILDRUN_DEPENDS=	openpam:single:standard
+BUILD_DEPENDS=		byacc:single:standard
+
+post-patch:
+	${REINPLACE_CMD} -e 's|/usr/local|${PREFIX}|g' \
+		${WRKSRC}/doas.c
+
+post-patch-dragonfly:
+	${REINPLACE_CMD} -e 's/Free/DragonFly/g' \
+		${WRKSRC}/Makefile
+
+do-install:
+	${INSTALL_PROGRAM} ${WRKSRC}/doas ${STAGEDIR}${PREFIX}/bin
+	${INSTALL_MAN} ${WRKSRC}/doas.1 ${STAGEDIR}${PREFIX}/share/man/man1
+	${INSTALL_MAN} ${WRKSRC}/doas.conf.5 ${STAGEDIR}${PREFIX}/share/man/man5


### PR DESCRIPTION
Sorry for pull-requesting a port that does not compile yet (at least for me) but I'm having a problem with ravenadm and I don't know if it's something wrong in the specification, a bug in ravenadm or something else.

I written the specification for the doas port (and it seems fine to me) but when I test the package ravenadm stops itself on building aspell-fo (why?) and shows a "banner" at the top with "Graceful shutdown in progress, so no new tasks will be started.". I tried killing ravenadm, rebooting, pressing random keys but nothing seems to unlock the situation.

I think is a problem with the specification because ravenadm builds other ports just fine.

Thanks and apologies again for pr'ing a non-finished port.