### PR TITLE
Strip LO...

### DIFF
--- a/bucket_39/libreoffice/specification
+++ b/bucket_39/libreoffice/specification
@@ -1,6 +1,7 @@
 DEF[PORTVERSION]=	6.0.3.1
 DEF[CXXWARN]=		-Wno-deprecated-declarations -Wno-undef Wno-unused-parameter -Wno-unused-function -Wno-unused-local-typedefs -Wno-unused-variable -Wno-ignored-qualifiers -Woverloaded-virtual
 DEF[PYTHON_SEARCH]=	python3.6 python3.5 python3.4 python2.7
+DEF[PROGRAM_BINARIES]=	oosplash regmerge regview ui-previewer uri-encode xpdfimport
 # ----------------------------------------------------------------------------
 
 NAMEBASE=		libreoffice
@@ -189,3 +190,11 @@ post-install:
 	${MKDIR} ${STAGEDIR}${PREFIX}/share/libreoffice/sdk/classes
 	${RM} -r ${STAGEDIR}${PREFIX}/lib/libreoffice/share/uno_packages
 	${RM} -r ${STAGEDIR}${PREFIX}/lib/libreoffice/sdk/share
+	${STRIP_CMD} ${STAGEDIR}${PREFIX}/lib/libreoffice/program/*.so*
+	${STRIP_CMD} ${STAGEDIR}${PREFIX}/lib/libreoffice/program/*.bin
+	${STRIP_CMD} ${STAGEDIR}${PREFIX}/lib/libreoffice/sdk/lib/*.so
+	${STRIP_CMD} ${STAGEDIR}${PREFIX}/lib/libreoffice/sdk/bin/*
+
+.for B in ${PROGRAM_BINARIES}
+	${STRIP_CMD} ${STAGEDIR}${PREFIX}/lib/libreoffice/program/${B}
+.endfor


### PR DESCRIPTION
...and save about 10 MB (compressed!) in size from the libreoffice-primary-standard package (wow, those debug symbols really add up!).

BTW: Testing the package fails - there are about 100 fatal errors regarding invalid paths of the various libraries. Is there any way to make ravenadm not complain about these since they seem to be for internal LO use only?

Anyway: I've tested LO on FreeBSD and it seems to work perfectly well. Clicking through a big Impress presentation and loading a several hundred pages long Writer Document (all with Umlauts and stuff) left a good first impression. :)