### PR TITLE
Add sbin/route and sbin/ifconfig to sysroot on fbsd

### DIFF
--- a/bucket_B4/ravensys-root/files/Makefile
+++ b/bucket_B4/ravensys-root/files/Makefile
@@ -141,6 +141,12 @@ Usr_Sbin_DragonFly= 	/usr/sbin/pw \
 Usr_Sbin_FreeBSD=	${Usr_Sbin_DragonFly}
 Usr_Sbin_Linux=		# end
 
+Sbin_DragonFly=		# end
+Sbin_FreeBSD=		/sbin/ifconfig \
+			/sbin/route \
+			# end
+Sbin_Linux=		# end
+
 static_lib_generic=	/usr/lib/libc.a \
 			/usr/lib/libm.a \
 			/usr/lib/librt.a \
@@ -563,6 +569,7 @@ install:
 		${DESTDIR}${BASE}/usr/include/rpc \
 		${DESTDIR}${BASE}/usr/include/rpcsvc \
 		${DESTDIR}${BASE}/usr/sbin \
+		${DESTDIR}${BASE}/sbin \
 		# end
 .if "${OPSYS}" == "DragonFly"
 	${MKDIR} \
@@ -619,6 +626,9 @@ install:
 .  for item in ${Usr_Sbin_${OPSYS}}
 	${BSD_INSTALL_PROGRAM} ../${OPSYS:tl}${item} ${DESTDIR}${BASE}/usr/sbin/
 .  endfor
+. for item in ${Sbin_${OPSYS}}
+	${BSD_INSTALL_PROGRAM} ../${OPSYS:tl}${item} ${DESTDIR}${BASE}/sbin/
+. endfor
 .  for item in ${Libexec_${OPSYS}}
 	${BSD_INSTALL_PROGRAM} ../${OPSYS:tl}${item} ${DESTDIR}${BASE}/libexec/
 .  endfor

--- a/bucket_B4/ravensys-root/manifests/plist.single.freebsd64
+++ b/bucket_B4/ravensys-root/manifests/plist.single.freebsd64
@@ -25,6 +25,8 @@
 %%BASE%%/bin/test
 %%BASE%%/bin/unlink
 %%BASE%%/libexec/ld-elf.so.1
+%%BASE%%/sbin/ifconfig
+%%BASE%%/sbin/route
 %%BASE%%/usr/bin/awk
 %%BASE%%/usr/bin/basename
 %%BASE%%/usr/bin/bsdcat
@@ -1158,13 +1160,13 @@
 %%BASE%%/usr/lib/%%SONAME_LIBUSBHID%%
 %%BASE%%/usr/lib/%%SONAME_LIBUTIL%%
 %%BASE%%/usr/lib/Scrt1.o
-%%BASE%%/usr/lib/libcompat.a
 %%BASE%%/usr/lib/crt1.o
 %%BASE%%/usr/lib/crti.o
 %%BASE%%/usr/lib/crtn.o
 %%BASE%%/usr/lib/gcrt1.o
 %%BASE%%/usr/lib/libc.a
 %%BASE%%/usr/lib/libc.so
+%%BASE%%/usr/lib/libcompat.a
 %%BASE%%/usr/lib/libcrypt.a
 %%BASE%%/usr/lib/libcrypt.so
 %%BASE%%/usr/lib/libdevstat.a

--- a/bucket_B4/ravensys-root/specification
+++ b/bucket_B4/ravensys-root/specification
@@ -11,7 +11,7 @@ DEF[GCCX]=		EXTRACT_INFO(CURRENT_GCC)
 
 NAMEBASE=		ravensys-root
 VERSION=		1.4
-REVISION=		3
+REVISION=		4
 KEYWORDS=		raven
 VARIANTS=		dragonfly freebsd64 linux sunos
 SDESC[dragonfly]=	DragonFly64 system root for Ravenports build env


### PR DESCRIPTION
Those two programs are needed to build OpenVPN on FreeBSD. Copying them manually into /raven/share/raven/sysroot/FreeBSD/usr/sbin makes the program configure and build successfully. I tried adding the files to the sysroot port for fbsd. Since the programs are located in /sbin, I chose that directory for the sysroot, too. However it looks like /sbin is not mounted in the build chroot. What is the correct solution for this? Copy them to usr/sbin anyway?