### PR TITLE
Bump revision on qt5-qtbase due to ICU update

### DIFF
--- a/bucket_1A/qt5-qtbase/specification
+++ b/bucket_1A/qt5-qtbase/specification
@@ -4,6 +4,7 @@ DEF[MINOR_VER]=		${PORTVERSION:R}
 
 NAMEBASE=		qt5-qtbase
 VERSION=		${PORTVERSION}
+REVISION=		1
 KEYWORDS=		x11_toolkits devel
 VARIANTS=		standard
 SDESC[standard]=	Qt5 - QtBase component

--- a/bucket_1A/qt5-qtbase/specification
+++ b/bucket_1A/qt5-qtbase/specification
@@ -4,7 +4,6 @@ DEF[MINOR_VER]=		${PORTVERSION:R}
 
 NAMEBASE=		qt5-qtbase
 VERSION=		${PORTVERSION}
-REVISION=		1
 KEYWORDS=		x11_toolkits devel
 VARIANTS=		standard
 SDESC[standard]=	Qt5 - QtBase component
@@ -22,6 +21,7 @@ OPTIONS_STANDARD=	none
 
 BUILDRUN_DEPENDS=	pcre2:primary:standard
 			harfbuzz:icu:standard
+			icu:single:standard
 # |			libproxy:single:standard
 			libxkbcommon:single:standard
 			at-spi2-atk:single:standard

--- a/bucket_39/libreoffice/specification
+++ b/bucket_39/libreoffice/specification
@@ -47,6 +47,7 @@ RUN_DEPENDS=		fonts-crosextra-caladea:single:standard
 			fonts-linuxlibertine:single:standard
 BUILDRUN_DEPENDS=	serf:single:standard
 			harfbuzz:icu:standard
+			icu:single:standard
 			libe-book:single:standard
 			libabw:single:standard
 			libcdr:single:standard


### PR DESCRIPTION
Building the newest version of (e.g.) keepassxc currently fails with

`Shared object "libicui18n.so.60" not found, required by "libQt5Core.so.5"`

Bumping the revision on qt5-qtbase fixes this.