### PR TITLE
xmlada: upgrade

### DIFF
--- a/bucket_96/xmlada/distinfo
+++ b/bucket_96/xmlada/distinfo
@@ -1,1 +1,1 @@
-5e8f15a335dc4ce114a90dd5dcf23b48374f21fa57abc0715a06cd5e4b157ed5      1021297 AdaCore-xmlada-fce5c96.tar.gz
+aacef3ae91e701690f60bde9c8a4a3f47ba8ca1f8f3c0599d01bce0173be80de      1582215 xmlada-gpl-2018-src.tar.gz

--- a/bucket_96/xmlada/specification
+++ b/bucket_96/xmlada/specification
@@ -1,4 +1,4 @@
-DEF[PORTVERSION]=	2017
+DEF[PORTVERSION]=	2018
 # ----------------------------------------------------------------------------
 
 NAMEBASE=		xmlada
@@ -6,12 +6,12 @@ VERSION=		${PORTVERSION}
 KEYWORDS=		textproc ada
 VARIANTS=		standard
 SDESC[standard]=	Adacore XML suite for the Ada language
-HOMEPAGE=		http://libre.adacore.com/libre/tools/xmlada/
+HOMEPAGE=		https://www2.adacore.com/gnatpro/toolsuite/xmlada
 CONTACT=		John_Marino[draco@marino.st]
 
 DOWNLOAD_GROUPS=	main
-SITES[main]=		GITHUB/AdaCore:xmlada:fce5c96
-DISTFILE[1]=		generated:main
+SITES[main]=		http://ravenports.elderlinux.org/distcache/ada/
+DISTFILE[1]=		xmlada-gpl-${PORTVERSION}-src.tar.gz:main
 DF_INDEX=		1
 SPKGS[standard]=	complete
 			primary
@@ -37,6 +37,7 @@ MAKEFILE=		Makefile.bsd
 MAKE_ARGS=		LIBVER=${PORTVERSION}
 			PROCESSORS={{MAKE_JOBS_NUMBER}}
 
+DISTNAME=		xmlada-gpl-${PORTVERSION}-src
 PLIST_SUB=		LIBVER=${PORTVERSION}
 
 post-patch:


### PR DESCRIPTION
A first attempt to get the various Ada ports updated. I'm not familiar with the Ada ecosystem at all, but I'm trying to make a best guess. To me it looks like a whole lot of stuff got moved around: The homepage defined in the specification does not longer exist - libre.adacore is now a redirect. I tried to find a page that could be a replacement, please take a look if that one's ok (or if e.g. pointing to GH makes more sense).

I couldn't find out what commit to refer for the 2018 release, so I settled for taking the distfiles from a Gentoo mirror. If this PR can be merged, I'll try to get the other Ada packages updated, too, so we could get a few long-standing outdated ones out of the way.