### PR TITLE
Add dmidecode

### DIFF
--- a/bucket_F9/dmidecode/descriptions/desc.single
+++ b/bucket_F9/dmidecode/descriptions/desc.single
@@ -1,0 +1,17 @@
+Dmidecode reports information about your system's hardware as described in 
+your system BIOS according to the SMBIOS/DMI standard. This information 
+typically includes system manufacturer, model name, serial number, BIOS 
+version, asset tag as well as a lot of other details of varying level of 
+interest and reliability depending on the manufacturer. It will often 
+include usage status for the CPU sockets, expansion slots (e.g. AGP, PCI, 
+ISA) and memory module slots, and the list of I/O ports (e.g. serial, 
+parallel, USB).
+
+DMI data can be used to enable or disable specific portions of kernel code 
+depending on the specific hardware. Thus, one use of dmidecode is for 
+kernel developers to detect system "signatures" and add them to the kernel 
+source code when needed.
+
+Beware that DMI data have proven to be too unreliable to be blindly 
+trusted. Dmidecode does not scan your hardware, it only reports what the 
+BIOS told it to.

--- a/bucket_F9/dmidecode/distinfo
+++ b/bucket_F9/dmidecode/distinfo
@@ -1,0 +1,1 @@
+d766ce9b25548c59b1e7e930505b4cad9a7bb0b904a1a391fbb604d529781ac0        61204 dmidecode-3.1.tar.xz

--- a/bucket_F9/dmidecode/dragonfly/patch-dmidecode.c
+++ b/bucket_F9/dmidecode/dragonfly/patch-dmidecode.c
@@ -1,0 +1,16 @@
+This allows to have dmidecode -t 17 working on non-uefi boots to fetch info
+about RAM modules and other bits.
+For it to work on uefi boots, something like this FreeBSD r307326 or
+86804dadc870572c2149fec3ca1d6561a762ffc5 would be needed in loader.efi
+
+--- dmidecode.c.intermediate	2017-12-05 11:44:42.000000000 +0200
++++ dmidecode.c
+@@ -4982,6 +4982,8 @@ static int address_from_efi(off_t *addre
+ 	if (ret == EFI_NO_SMBIOS)
+ 		fprintf(stderr, "%s: SMBIOS entry point missing\n", filename);
+ 	return ret;
++#elif defined(__DragonFly__)
++	return EFI_NOT_FOUND; /* XXX */
+ #elif defined(__FreeBSD__)
+ 	/*
+ 	 * On FreeBSD, SMBIOS anchor base address in UEFI mode is exposed

--- a/bucket_F9/dmidecode/files/dmidecode.in
+++ b/bucket_F9/dmidecode/files/dmidecode.in
@@ -1,0 +1,53 @@
+#!/bin/sh -
+#
+# Copyright (c) 2001-2014  The FreeBSD Project
+# Copyright (c) 2014	Dmitry Morozovsky <marck@rinet.ru>
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+# OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+# SUCH DAMAGE.
+#
+# $FreeBSD: head/sysutils/dmidecode/files/dmidecode.in 403097 2015-12-06 10:04:50Z pi $
+#
+
+# If there is a global system configuration file, suck it in.
+#
+if [ -r /etc/defaults/periodic.conf ]
+then
+    . /etc/defaults/periodic.conf
+    source_periodic_confs
+fi
+
+dmidecode=%%PREFIX%%/sbin/dmidecode
+
+. /etc/periodic/security/security.functions
+
+rc=0
+
+case "$daily_status_dmidecode_enable" in
+    [Yy][Ee][Ss])
+	$dmidecode 2>/dev/null |
+	    check_diff dmidecode - "${host} hardware dmi status:"
+	rc=$?;;
+    *)	rc=0;;
+esac
+
+exit $rc

--- a/bucket_F9/dmidecode/freebsd/patch-dmidecode.c
+++ b/bucket_F9/dmidecode/freebsd/patch-dmidecode.c
@@ -1,0 +1,58 @@
+--- dmidecode.c.orig	2017-05-23 13:34:14 UTC
++++ dmidecode.c
+@@ -58,6 +58,10 @@
+  *    https://trustedcomputinggroup.org/pc-client-platform-tpm-profile-ptp-specification/
+  */
+ 
++#ifdef __FreeBSD__
++#include <errno.h>
++#include <kenv.h>
++#endif
+ #include <stdio.h>
+ #include <string.h>
+ #include <strings.h>
+@@ -4934,13 +4938,18 @@ static int legacy_decode(u8 *buf, const 
+ #define EFI_NO_SMBIOS   (-2)
+ static int address_from_efi(off_t *address)
+ {
++#if defined(__linux__)
+ 	FILE *efi_systab;
+ 	const char *filename;
+ 	char linebuf[64];
++#elif defined(__FreeBSD__)
++	char addrstr[KENV_MVALLEN + 1];
++#endif
+ 	int ret;
+ 
+ 	*address = 0; /* Prevent compiler warning */
+ 
++#if defined(__linux__)
+ 	/*
+ 	 * Linux up to 2.6.6: /proc/efi/systab
+ 	 * Linux 2.6.7 and up: /sys/firmware/efi/systab
+@@ -4973,6 +4982,25 @@ static int address_from_efi(off_t *addre
+ 	if (ret == EFI_NO_SMBIOS)
+ 		fprintf(stderr, "%s: SMBIOS entry point missing\n", filename);
+ 	return ret;
++#elif defined(__FreeBSD__)
++	/*
++	 * On FreeBSD, SMBIOS anchor base address in UEFI mode is exposed
++	 * via kernel environment:
++	 * https://svnweb.freebsd.org/base?view=revision&revision=307326
++	 */
++	ret = kenv(KENV_GET, "hint.smbios.0.mem", addrstr, sizeof(addrstr));
++	if (ret == -1) {
++		if (errno != ENOENT)
++			perror("kenv");
++		return EFI_NOT_FOUND;
++	}
++
++	*address = strtoull(addrstr, NULL, 0);
++	if (!(opt.flags & FLAG_QUIET))
++		printf("# SMBIOS entry point at 0x%08llx\n",
++		    (unsigned long long)*address);
++	return 0;
++#endif
+ }
+ 
+ int main(int argc, char * const argv[])

--- a/bucket_F9/dmidecode/manifests/plist.single
+++ b/bucket_F9/dmidecode/manifests/plist.single
@@ -1,0 +1,11 @@
+sbin/ownership
+sbin/vpddecode
+sbin/biosdecode
+sbin/dmidecode
+share/doc/dmidecode/README
+share/doc/dmidecode/AUTHORS
+share/doc/dmidecode/CHANGELOG
+share/man/man8/biosdecode.8.gz
+share/man/man8/dmidecode.8.gz
+share/man/man8/ownership.8.gz
+share/man/man8/vpddecode.8.gz

--- a/bucket_F9/dmidecode/manifests/plist.single
+++ b/bucket_F9/dmidecode/manifests/plist.single
@@ -9,3 +9,5 @@ share/man/man8/biosdecode.8.gz
 share/man/man8/dmidecode.8.gz
 share/man/man8/ownership.8.gz
 share/man/man8/vpddecode.8.gz
+%%ONLY-FREEBSD%%etc/periodic/daily/dmidecode
+%%ONLY-DRAGONFLY%%etc/periodic/daily/dmidecode

--- a/bucket_F9/dmidecode/specification
+++ b/bucket_F9/dmidecode/specification
@@ -28,5 +28,14 @@ LICENSE_SCHEME=		solo
 FPC_EQUIVALENT=		sysutils/dmidecode
 
 NOT_FOR_ARCH=		aarch64
+SUB_FILES=		dmidecode
 
 MAKE_ARGS=		prefix={{PREFIX}}
+
+post-install-dragonfly:
+	${MKDIR} ${STAGEDIR}${PREFIX}/etc/periodic/daily
+	${INSTALL_SCRIPT} ${WRKDIR}/dmidecode ${STAGEDIR}${PREFIX}/etc/periodic/daily/
+
+post-install-freebsd:
+	${MKDIR} ${STAGEDIR}${PREFIX}/etc/periodic/daily
+	${INSTALL_SCRIPT} ${WRKDIR}/dmidecode ${STAGEDIR}${PREFIX}/etc/periodic/daily/

--- a/bucket_F9/dmidecode/specification
+++ b/bucket_F9/dmidecode/specification
@@ -1,0 +1,32 @@
+DEF[PORTVERSION]=	3.1
+# ----------------------------------------------------------------------------
+
+NAMEBASE=		dmidecode
+VERSION=		${PORTVERSION}
+KEYWORDS=		sysutils
+VARIANTS=		standard
+SDESC[standard]=	Dump DMI/SMBIOS information as human-readable text
+HOMEPAGE=		https://www.nongnu.org/dmidecode
+CONTACT=		Michael_Reim[kraileth@elderlinux.org]
+
+DOWNLOAD_GROUPS=	main
+SITES[main]=		http://download.savannah.gnu.org/releases/dmidecode/
+DISTFILE[1]=		dmidecode-${PORTVERSION}.tar.xz:main
+
+SPKGS[standard]=	single
+
+OPTIONS_AVAILABLE=	none
+OPTIONS_STANDARD=	none
+
+LICENSE=		GPLv2+:single
+LICENSE_FILE=		GPLv2+:{{WRKSRC}}/LICENSE
+LICENSE_TERMS=		single:{{WRKDIR}}/TERMS
+LICENSE_AWK=		TERMS:"^$$"
+LICENSE_SOURCE=		TERMS:{{WRKSRC}}/dmidecode.h
+LICENSE_SCHEME=		solo
+
+FPC_EQUIVALENT=		sysutils/dmidecode
+
+NOT_FOR_ARCH=		aarch64
+
+MAKE_ARGS=		prefix={{PREFIX}}


### PR DESCRIPTION
Please have a look at this port and try it out on dfly - I just copied the patch from dports but don't have any Dragonfly machine at hand. I left out the Makefile patch from the FPC since the port builds without it and to me it seemed only relevant to make dmidecode build with FreeBSD's clang.

BTW: The FreeBSD port has another file, dmidecode.in. How should periodic scripts be treated? Do we want those? If yes: Can they just be copied over or is this a bit much to take in addition to patches?

If we don't want that additional file and the port works on dfly, it can be committed. (Unless you want me to remove the "DOC" files installed by default or something like that.)