### PR TITLE
add siren port

### DIFF
--- a/bucket_DC/siren/descriptions/desc.single
+++ b/bucket_DC/siren/descriptions/desc.single
@@ -1,0 +1,3 @@
+Siren is a text-based audio player for UNIX-like operating systems. It
+supports Ogg Vorbis, MP3, FLAC, WavPack, WAVE, AIFF and many other file
+formats.

--- a/bucket_DC/siren/distinfo
+++ b/bucket_DC/siren/distinfo
@@ -1,0 +1,1 @@
+5ee79aec712f3605c720fd92af93e8a7258d734f48b97dcb09e15baad3d049e3       100553 siren-0.8.tar.gz

--- a/bucket_DC/siren/manifests/plist.single
+++ b/bucket_DC/siren/manifests/plist.single
@@ -1,0 +1,10 @@
+bin/siren
+lib/siren/ip/ffmpeg.so
+lib/siren/ip/flac.so
+lib/siren/ip/mad.so
+lib/siren/ip/mpg123.so
+lib/siren/ip/sndfile.so
+lib/siren/ip/vorbis.so
+lib/siren/ip/wavpack.so
+lib/siren/op/ao.so
+share/man/man1/siren.1.gz

--- a/bucket_DC/siren/patches/patch-compat_tree.h
+++ b/bucket_DC/siren/patches/patch-compat_tree.h
@@ -1,0 +1,11 @@
+--- compat/tree.h.orig	2018-09-28 12:31:52.435530000 +0300
++++ compat/tree.h	2018-09-28 12:33:41.057478000 +0300
+@@ -27,6 +27,8 @@
+ #ifndef	_SYS_TREE_H_
+ #define	_SYS_TREE_H_
+ 
++#include <stddef.h>
++
+ /*
+  * This file defines data structures for different types of trees:
+  * splay trees and red-black trees.

--- a/bucket_DC/siren/specification
+++ b/bucket_DC/siren/specification
@@ -1,0 +1,55 @@
+DEF[PORTVERSION]=	0.8
+# ----------------------------------------------------------------------------
+
+NAMEBASE=		siren
+VERSION=		${PORTVERSION}
+KEYWORDS=		audio
+VARIANTS=		standard
+SDESC[standard]=	Text-based audio player
+HOMEPAGE=		https://www.kariliq.nl/siren/
+CONTACT=		Leonid_Bobrov[mazocomp@disroot.org]
+
+DOWNLOAD_GROUPS=	main
+SITES[main]=		https://www.kariliq.nl/siren/dist
+DISTFILE[1]=		siren-${PORTVERSION}.tar.gz:main
+
+SPKGS[standard]=	single
+
+OPTIONS_AVAILABLE=	none
+OPTIONS_STANDARD=	none
+
+LICENSE=		ISCL:single
+LICENSE_FILE=		ISCL:{{WRKSRC}}/LICENSE
+LICENSE_SCHEME=		solo
+
+FPC_EQUIVALENT=		audio/siren
+
+BUILDRUN_DEPENDS=	flac:primary:standard
+			ffmpeg:primary:standard
+			libao:primary:standard
+			libid3tag:single:standard
+			libmad:single:standard
+			libsndfile:primary:standard
+			libvorbis:primary:standard
+			mpg123:single:standard
+			wavpack:single:standard
+
+USES=			ncurses pkgconfig
+CFLAGS=			-I{{NCURSESINC}}
+
+MUST_CONFIGURE=		yes
+
+CONFIGURE_ARGS=		aac=no
+			alsa=no
+			debug=no
+			mandir={{MANPREFIX}}/man
+			oss=no
+			opus=no
+			portaudio=no
+			prefix={{PREFIX}}
+			pulse=no
+			sndio=no
+			sun=no
+
+post-extract:
+	${REINPLACE_CMD} -e 's|-lcurses|-lncurses|' ${WRKSRC}/configure


### PR DESCRIPTION
Text-based audio player.

TODO:
* port opusfile and add opus support.
* add options for output backend (not necessary, it's better to use cross-platform sndio, libav and/or portaudio).
* improve description? (I don't like the one taken from FreeBSD)