### PR TITLE
add libopusenc and opus-tools ports

### DIFF
--- a/bucket_39/opus-tools/descriptions/desc.single
+++ b/bucket_39/opus-tools/descriptions/desc.single
@@ -1,0 +1,2 @@
+Opus-tools provides command-line utilities to encode, inspect, and
+decode .opus files.

--- a/bucket_39/opus-tools/distinfo
+++ b/bucket_39/opus-tools/distinfo
@@ -1,0 +1,1 @@
+b4e56cb00d3e509acfba9a9b627ffd8273b876b4e2408642259f6da28fa0ff86       457680 opus-tools-0.2.tar.gz

--- a/bucket_39/opus-tools/manifests/plist.single
+++ b/bucket_39/opus-tools/manifests/plist.single
@@ -1,0 +1,6 @@
+bin/opusdec
+bin/opusenc
+bin/opusinfo
+share/man/man1/opusdec.1.gz
+share/man/man1/opusenc.1.gz
+share/man/man1/opusinfo.1.gz

--- a/bucket_39/opus-tools/specification
+++ b/bucket_39/opus-tools/specification
@@ -1,0 +1,41 @@
+DEF[PORTVERSION]=	0.2
+# ----------------------------------------------------------------------------
+
+NAMEBASE=		opus-tools
+VERSION=		${PORTVERSION}
+KEYWORDS=		audio
+VARIANTS=		standard
+SDESC[standard]=	Encode, inspect, and decode Opus files
+HOMEPAGE=		https://www.opus-codec.org/
+CONTACT=		Leonid_Bobrov[mazocomp@disroot.org]
+
+DOWNLOAD_GROUPS=	main
+SITES[main]=		https://download.cdn.mozilla.net/pub/opus/
+			https://downloads.xiph.org/releases/opus/
+			https://archive.mozilla.org/pub/opus/
+DISTFILE[1]=		opus-tools-${PORTVERSION}.tar.gz:main
+
+SPKGS[standard]=	single
+
+OPTIONS_AVAILABLE=	none
+OPTIONS_STANDARD=	none
+
+LICENSE=		BSD2CLAUSE:single
+			GPLv2:single
+LICENSE_FILE=		BSD2CLAUSE:{{WRKDIR}}/LICENSE
+			GPLv2:{{WRKDIR}}/LICENSE
+LICENSE_TERMS=		single:{{WRKSRC}}/TERMS
+LICENSE_AWK=		TERMS:"^\#ifdef"
+LICENSE_SOURCE=		TERMS:{{WRKSRC}}/src/opusinfo.c
+LICENSE_SCHEME=		multi
+
+FPC_EQUIVALENT=		audio/opus-tools
+
+USES=			pkgconfig
+
+MUST_CONFIGURE=		gnu
+
+BUILDRUN_DEPENDS=	flac:primary:standard
+			libogg:primary:standard
+			libopusenc:primary:standard
+			opusfile:primary:standard

--- a/bucket_D8/libopusenc/descriptions/desc.primary
+++ b/bucket_D8/libopusenc/descriptions/desc.primary
@@ -1,0 +1,2 @@
+The libopusenc libraries provide a high-level API for encoding .opus
+files.

--- a/bucket_D8/libopusenc/distinfo
+++ b/bucket_D8/libopusenc/distinfo
@@ -1,0 +1,1 @@
+c79e95eeee43a0b965e9b2c59a243763a8f8b0a7e71441df2aa9084f6171c73a       388027 libopusenc-0.2.tar.gz

--- a/bucket_D8/libopusenc/manifests/plist.primary
+++ b/bucket_D8/libopusenc/manifests/plist.primary
@@ -1,0 +1,6 @@
+include/opus/opusenc.h
+lib/libopusenc.a
+lib/libopusenc.so
+lib/libopusenc.so.%%SOMAJOR%%
+lib/libopusenc.so.%%SOVERSION%%
+lib/pkgconfig/libopusenc.pc

--- a/bucket_D8/libopusenc/specification
+++ b/bucket_D8/libopusenc/specification
@@ -1,0 +1,34 @@
+DEF[PORTVERSION]=	0.2
+DEF[SOVERSION]=		0.4.2
+# ----------------------------------------------------------------------------
+
+NAMEBASE=		libopusenc
+VERSION=		${PORTVERSION}
+KEYWORDS=		audio
+VARIANTS=		standard
+SDESC[standard]=	High-level API for encoding .opus files
+HOMEPAGE=		https://www.opus-codec.org/
+CONTACT=		Leonid_Bobrov[mazocomp@disroot.org]
+
+DOWNLOAD_GROUPS=	main
+SITES[main]=		https://download.cdn.mozilla.net/pub/opus/
+			https://downloads.xiph.org/releases/opus/
+			https://archive.mozilla.org/pub/opus/
+DISTFILE[1]=		libopusenc-${PORTVERSION}.tar.gz:main
+
+SPKGS[standard]=	complete primary docs
+
+OPTIONS_AVAILABLE=	none
+OPTIONS_STANDARD=	none
+
+LICENSE=		BSD3CLAUSE:primary
+LICENSE_FILE=		BSD3CLAUSE:{{WRKSRC}}/COPYING
+LICENSE_SCHEME=		solo
+
+FPC_EQUIVALENT=		audio/opus-tools
+
+USES=			gmake libtool pkgconfig
+MUST_CONFIGURE=		gnu
+BUILDRUN_DEPENDS=	opus:single:standard
+INSTALL_TARGET=		install-strip
+SOVERSION=		${SOVERSION}


### PR DESCRIPTION
Opus-tools provides command-line utilities to encode, inspect, and decode .opus files.

libopusenc is opus-tools's new dependency.

Don't hurry to merge, opus-tools is multi licensed and stores both BSD and GPL in one file and that causes error at test, adding GPLv2:stock didn't help :/

Tested at DragonFlyBSD