### PR TITLE
add slop and maim ports

### DIFF
--- a/bucket_B4/maim/descriptions/desc.single
+++ b/bucket_B4/maim/descriptions/desc.single
@@ -1,0 +1,12 @@
+maim (Make Image) is a utility that takes screenshots of your desktop using
+imlib2. It's meant to overcome shortcomings of scrot and performs better
+in several ways.
+
+Features:
+* Allows you to take a screenshot of your desktop and save it in any format.
+* Allows you to take a screenshot of a predetermined region or window of
+  your desktop.
+* If slop is installed, it can be used for selecting a region to screenshot.
+* Allows you to blend the system cursor into screenshots.
+* Allows you to mask off-screen pixels to be black and transparent in
+  screenshots. (Great for people who use an uneven multi-monitor setup!)

--- a/bucket_B4/maim/distinfo
+++ b/bucket_B4/maim/distinfo
@@ -1,0 +1,1 @@
+254563b89c52dcf1fab713c0221db7f3f1a37ec539ecc5512daf5916ba86ed93        39619 naelstrof-maim-5.5.2.tar.gz

--- a/bucket_B4/maim/manifests/plist.single
+++ b/bucket_B4/maim/manifests/plist.single
@@ -1,0 +1,2 @@
+bin/maim
+share/man/man1/maim.1.gz

--- a/bucket_B4/maim/specification
+++ b/bucket_B4/maim/specification
@@ -1,0 +1,39 @@
+DEF[PORTVERSION]=	5.5.2
+# ----------------------------------------------------------------------------
+
+NAMEBASE=		maim
+VERSION=		${PORTVERSION}
+KEYWORDS=		graphics x11
+VARIANTS=		standard
+SDESC[standard]=	Desktop screenshot utility (make image)
+HOMEPAGE=		https://github.com/naelstrof/maim
+CONTACT=		Leonid_Bobrov[mazocomp@disroot.org]
+
+DOWNLOAD_GROUPS=	main
+SITES[main]=		GITHUB/naelstrof:maim:v${PORTVERSION}
+DISTFILE[1]=		generated:main
+
+SPKGS[standard]=	single
+
+OPTIONS_AVAILABLE=	none
+OPTIONS_STANDARD=	none
+
+LICENSE=		GPLv3:single
+LICENSE_FILE=		GPLv3:{{WRKSRC}}/COPYING
+LICENSE_TERMS=		single:{{WRKSRC}}/license.txt
+LICENSE_SCHEME=		solo
+
+FPC_EQUIVALENT=		graphics/maim
+
+USES=			cmake:outsource jpeg
+
+BUILD_DEPENDS=		glm:single:standard
+
+BUILDRUN_DEPENDS=	icu:single:standard
+			imlib2:single:standard
+			png:single:standard
+			slop:single:standard
+			xorg-sm:single:standard
+			xorg-xcomposite:single:standard
+			xorg-xext:single:standard
+			xorg-xrender:single:standard

--- a/bucket_CB/slop/descriptions/desc.single
+++ b/bucket_CB/slop/descriptions/desc.single
@@ -1,0 +1,23 @@
+slop (Select Operation) is an application that querys for a selection
+from the user and prints the region to stdout. It grabs the mouse and
+turns it into a crosshair, lets the user click and drag to make a
+selection (or click on a window) while drawing a pretty box around it,
+then finally prints the selection's dimensions to stdout.
+
+Features:
+* Hovering over a window will cause a selection rectangle to appear over
+  it.
+* Clicking on a window makes slop return the dimensions of the window.
+* Clicking and dragging causes a selection rectangle to appear, renders
+  pretty well (compared to scrot). And will return the dimensions of
+  that rectangle in absolute screen coords.
+* On startup it turns your cursor into a crosshair, then adjusts the
+  cursor into angles as you drag the selection rectangle.
+* Supports simple arguments:
+	* Change selection rectangle border size.
+	* Select X display.
+	* Set padding size, even negative padding sizes!
+	* Set click tolerance for if you have a shaky mouse.
+	* Set the color of the selection rectangles to match your theme!
+	  (Even supports transparency!)
+	* Remove window decorations from selections.

--- a/bucket_CB/slop/distinfo
+++ b/bucket_CB/slop/distinfo
@@ -1,0 +1,1 @@
+8868590b0ebb712f82295266cb120f5bda022393d72caafa7564c9fb66ccedce        50079 naelstrof-slop-7.4.tar.gz

--- a/bucket_CB/slop/manifests/plist.single
+++ b/bucket_CB/slop/manifests/plist.single
@@ -1,0 +1,5 @@
+bin/slop
+include/slop.hpp
+lib/libslopy.so
+lib/libslopy.so.7.4
+share/man/man1/slop.1.gz

--- a/bucket_CB/slop/specification
+++ b/bucket_CB/slop/specification
@@ -1,0 +1,34 @@
+DEF[PORTVERSION]=	7.4
+# ----------------------------------------------------------------------------
+
+NAMEBASE=		slop
+VERSION=		${PORTVERSION}
+KEYWORDS=		graphics x11
+VARIANTS=		standard
+SDESC[standard]=	Query for a selection and print to stdout
+HOMEPAGE=		https://github.com/naelstrof/slop
+CONTACT=		Leonid_Bobrov[mazocomp@disroot.org]
+
+DOWNLOAD_GROUPS=	main
+SITES[main]=		GITHUB/naelstrof:slop:v${PORTVERSION}
+DISTFILE[1]=		generated:main
+
+SPKGS[standard]=	single
+
+OPTIONS_AVAILABLE=	none
+OPTIONS_STANDARD=	none
+
+LICENSE=		GPLv3:single
+LICENSE_FILE=		GPLv3:{{WRKSRC}}/COPYING
+LICENSE_TERMS=		single:{{WRKSRC}}/license.txt
+LICENSE_SCHEME=		solo
+
+FPC_EQUIVALENT=		x11/slop
+
+USES=			cmake:outsource
+
+BUILD_DEPENDS=		glm:single:standard
+
+BUILDRUN_DEPENDS=	glew:primary:standard
+			icu:single:standard
+			libGLU:single:standard


### PR DESCRIPTION
I was going to actually port scrot and its dependency giblib, but I changed my mind and thanks to description I know scrot is abandonware and maim is a better option, so here I port maim screenshooter and its dependency slop. 

Tested at DragonFlyBSD :)