### PR TITLE
wtf and aspell-ro: use SF shortcut in SITES

### DIFF
--- a/bucket_27/wtf/specification
+++ b/bucket_27/wtf/specification
@@ -11,7 +11,7 @@ HOMEPAGE=		none
 CONTACT=		Leonid_Bobrov[mazocomp@disroot.org]
 
 DOWNLOAD_GROUPS=	main
-SITES[main]=		https://downloads.sourceforge.net/project/bsdwtf/
+SITES[main]=		SF/bsdwtf
 DISTFILE[1]=		wtf-${PORTVERSION}.tar.gz:main
 
 SPKGS[standard]=	single

--- a/bucket_57/aspell-ro/specification
+++ b/bucket_57/aspell-ro/specification
@@ -15,7 +15,7 @@ HOMEPAGE=		https://rospell.wordpress.com/
 CONTACT=		nobody
 
 DOWNLOAD_GROUPS=	main
-SITES[main]=		http://downloads.sourceforge.net/rospell/
+SITES[main]=		SF/rospell/Romanian%20dictionaries/dict-${PORTVERSION}
 DISTFILE[1]=		${DISTPREFIX}-${SUFFIX}-${PORTVERSION}.tar.bz2:main
 
 SPKGS[standard]=	single


### PR DESCRIPTION
The only port left is a52dec, but unfortunately it's impossible to do that for it, it's files directory at sourceforge is empty.