### PR TITLE
graphics/mesa-dri: Disable soft-spinning of all buffers

### DIFF
--- a/bucket_F0/mesa/dragonfly/patch-src_mesa_drivers_dri_i965_brw__bufmgr.c
+++ b/bucket_F0/mesa/dragonfly/patch-src_mesa_drivers_dri_i965_brw__bufmgr.c
@@ -1,0 +1,11 @@
+--- src/mesa/drivers/dri/i965/brw_bufmgr.c.orig	2019-01-17 11:26:23 UTC
++++ src/mesa/drivers/dri/i965/brw_bufmgr.c
+@@ -1721,7 +1721,7 @@ brw_bufmgr_init(struct gen_device_info *
+       bufmgr->initial_kflags |= EXEC_OBJECT_SUPPORTS_48B_ADDRESS;
+ 
+       /* Allocate VMA in userspace if we have softpin and full PPGTT. */
+-      if (gem_param(fd, I915_PARAM_HAS_EXEC_SOFTPIN) > 0 &&
++      if (false && gem_param(fd, I915_PARAM_HAS_EXEC_SOFTPIN) > 0 &&
+           gem_param(fd, I915_PARAM_HAS_ALIASING_PPGTT) > 1) {
+          bufmgr->initial_kflags |= EXEC_OBJECT_PINNED;
+ 


### PR DESCRIPTION
* It is broken with current DragonFly 5.4 and 5.5 kernels

* This patch is a revert of Mesa's a363bb2cd0e2a141f2c60be005009703bffcbe4e
  "i965: Allocate VMA in userspace for full-PPGTT systems."