### PR TITLE
fdm: VAR_OPSYS[dragonfly] is no longer needed

### DIFF
--- a/bucket_1C/fdm/specification
+++ b/bucket_1C/fdm/specification
@@ -36,8 +36,6 @@ CONFIGURE_ARGS=		--sysconfdir={{PREFIX}}/etc
 CFLAGS=			-DPCRE
 LDFLAGS=		-lpcre
 
-VAR_OPSYS[dragonfly]=	CFLAGS=-DMAXNAMLEN=255
-
 post-patch:
 	${REINPLACE_CMD} -e 's|/etc|${PREFIX}/etc|g' ${WRKSRC}/*.[15] ${WRKSRC}/MANUAL
 	${ECHO_CMD} 'lex.c: parse.h' >> ${WRKSRC}/Makefile.am


### PR DESCRIPTION
https://github.com/nicm/fdm/pull/49
https://github.com/nicm/fdm/commit/f90a5b0cc8d881ddb886c74c5bff510a56f2ba74