### PR TITLE
warsow: remove snd_openal module

### DIFF
--- a/bucket_30/warsow/distinfo
+++ b/bucket_30/warsow/distinfo
@@ -1,1 +1,1 @@
-a98e52fd2175a049f0f2da77faf4415e3ab71372b6a454a1d040d63ccb426c69     14547835 OrangeGrayCyan-warsow-2.1.2-source.tar.gz
+aa3c416d94e333f774c465b70eb5a84ac6f2d815433eaa158227acd3b8c4a9f0     14542091 OrangeGrayCyan-warsow-2.1.2-qf.tar.gz

--- a/bucket_30/warsow/manifests/plist.single
+++ b/bucket_30/warsow/manifests/plist.single
@@ -8,7 +8,6 @@ share/warsow/libs/libcin.so
 share/warsow/libs/libftlib.so
 share/warsow/libs/libirc.so
 share/warsow/libs/libref_gl.so
-share/warsow/libs/libsnd_openal.so
 share/warsow/libs/libsnd_qf.so
 share/warsow/libs/libsteamlib.so
 share/warsow/libs/libui.so

--- a/bucket_30/warsow/specification
+++ b/bucket_30/warsow/specification
@@ -3,6 +3,7 @@ DEF[PORTVERSION]=	2.1.2
 
 NAMEBASE=		warsow
 VERSION=		${PORTVERSION}
+REVISION=		1
 KEYWORDS=		games
 VARIANTS=		standard
 SDESC[standard]=	Futuristic, fast-paced first person shooter
@@ -10,7 +11,7 @@ HOMEPAGE=		https://warsow.net/
 CONTACT=		Leonid_Bobrov[mazocomp@disroot.org]
 
 DOWNLOAD_GROUPS=	main
-SITES[main]=		GITHUB/OrangeGrayCyan:warsow:${PORTVERSION}-source
+SITES[main]=		GITHUB/OrangeGrayCyan:warsow:${PORTVERSION}-qf
 DISTFILE[1]=		generated:main
 
 SPKGS[standard]=	single
@@ -29,8 +30,7 @@ FPC_EQUIVALENT=		games/warsow
 
 USES=			c++:single cmake
 CMAKE_SOURCE_PATH=	{{WRKSRC}}/source
-BUILD_DEPENDS=		openal:single:standard
-			zlib:static:standard
+BUILD_DEPENDS=		zlib:static:standard
 RUN_DEPENDS=		warsow-data:single:standard
 BUILDRUN_DEPENDS=	curl:primary:standard
 			freetype:primary:standard


### PR DESCRIPTION
First, openal is only a build dependency, in my fork I removed dlopen()'ing system-wide libraries. Second, it plays sound via snd_qf anyway (via sdl).