### PR TITLE
Improve warsow port.

### DIFF
--- a/bucket_30/warsow/distinfo
+++ b/bucket_30/warsow/distinfo
@@ -1,1 +1,1 @@
-aa3c416d94e333f774c465b70eb5a84ac6f2d815433eaa158227acd3b8c4a9f0     14542091 OrangeGrayCyan-warsow-2.1.2-qf.tar.gz
+8a3a42ce8e8e430ed8358c0668d9c05fd42c342baf2400afc863e5e6a74b0ea5     14425165 OrangeGrayCyan-warsow-2.1.2-pic.tar.gz

--- a/bucket_30/warsow/manifests/plist.single
+++ b/bucket_30/warsow/manifests/plist.single
@@ -9,5 +9,4 @@ share/warsow/libs/libftlib.so
 share/warsow/libs/libirc.so
 share/warsow/libs/libref_gl.so
 share/warsow/libs/libsnd_qf.so
-share/warsow/libs/libsteamlib.so
 share/warsow/libs/libui.so

--- a/bucket_30/warsow/specification
+++ b/bucket_30/warsow/specification
@@ -3,7 +3,7 @@ DEF[PORTVERSION]=	2.1.2
 
 NAMEBASE=		warsow
 VERSION=		${PORTVERSION}
-REVISION=		1
+REVISION=		2
 KEYWORDS=		games
 VARIANTS=		standard
 SDESC[standard]=	Futuristic, fast-paced first person shooter
@@ -11,7 +11,7 @@ HOMEPAGE=		https://warsow.net/
 CONTACT=		Leonid_Bobrov[mazocomp@disroot.org]
 
 DOWNLOAD_GROUPS=	main
-SITES[main]=		GITHUB/OrangeGrayCyan:warsow:${PORTVERSION}-qf
+SITES[main]=		GITHUB/OrangeGrayCyan:warsow:${PORTVERSION}-pic
 DISTFILE[1]=		generated:main
 
 SPKGS[standard]=	single
@@ -40,10 +40,3 @@ BUILDRUN_DEPENDS=	curl:primary:standard
 			png:single:standard
 			sdl2:single:standard
 			zlib:shared:standard
-INSTALL_WRKSRC=		{{WRKSRC}}/source/build
-
-do-install:
-	${MKDIR} ${STAGEDIR}${PREFIX}/share/warsow
-	${CP} -R ${INSTALL_WRKSRC}/basewsw ${STAGEDIR}${PREFIX}/share/warsow/
-	${CP} -R ${INSTALL_WRKSRC}/libs ${STAGEDIR}${PREFIX}/share/warsow/
-	${INSTALL_PROGRAM} ${INSTALL_WRKSRC}/w* ${STAGEDIR}${PREFIX}/bin


### PR DESCRIPTION
So, here are some improvements:
* removed useless steamlib module;
* all compiler warnings coming from Clang with -Wall -Werror are silenced;
* synced with warsow_2.1 branch from upstream (it contains bugfixes since release);
* few bugfixes from me, I mostly fixed conditions which always evaluate to true;
* install target is now in CMakeLists.txt;
* added -fpic flag to build at FreeBSD.