### PR TITLE
Warsow: Fix FPS limiter by removing sleeps.

### DIFF
--- a/bucket_30/warsow/distinfo
+++ b/bucket_30/warsow/distinfo
@@ -1,1 +1,1 @@
-8a3a42ce8e8e430ed8358c0668d9c05fd42c342baf2400afc863e5e6a74b0ea5     14425165 OrangeGrayCyan-warsow-2.1.2-pic.tar.gz
+9e610eff223164f12dcca27bcfe2907fd152d60b61ee9d657acdf69c066e0fac     14422106 OrangeGrayCyan-warsow-2.1.2-fps.tar.gz

--- a/bucket_30/warsow/distinfo
+++ b/bucket_30/warsow/distinfo
@@ -1,1 +1,1 @@
-9e610eff223164f12dcca27bcfe2907fd152d60b61ee9d657acdf69c066e0fac     14422106 OrangeGrayCyan-warsow-2.1.2-fps.tar.gz
+e5fd5cca018a7b5d2defc7876add56f30d9eb16c886e635e620c3d75500265d7     14419243 OrangeGrayCyan-warsow-2.1.2-dirent.tar.gz

--- a/bucket_30/warsow/specification
+++ b/bucket_30/warsow/specification
@@ -11,7 +11,7 @@ HOMEPAGE=		https://warsow.net/
 CONTACT=		Leonid_Bobrov[mazocomp@disroot.org]
 
 DOWNLOAD_GROUPS=	main
-SITES[main]=		GITHUB/OrangeGrayCyan:warsow:${PORTVERSION}-fps
+SITES[main]=		GITHUB/OrangeGrayCyan:warsow:${PORTVERSION}-dirent
 DISTFILE[1]=		generated:main
 
 SPKGS[standard]=	single

--- a/bucket_30/warsow/specification
+++ b/bucket_30/warsow/specification
@@ -3,7 +3,7 @@ DEF[PORTVERSION]=	2.1.2
 
 NAMEBASE=		warsow
 VERSION=		${PORTVERSION}
-REVISION=		2
+REVISION=		3
 KEYWORDS=		games
 VARIANTS=		standard
 SDESC[standard]=	Futuristic, fast-paced first person shooter
@@ -11,7 +11,7 @@ HOMEPAGE=		https://warsow.net/
 CONTACT=		Leonid_Bobrov[mazocomp@disroot.org]
 
 DOWNLOAD_GROUPS=	main
-SITES[main]=		GITHUB/OrangeGrayCyan:warsow:${PORTVERSION}-pic
+SITES[main]=		GITHUB/OrangeGrayCyan:warsow:${PORTVERSION}-fps
 DISTFILE[1]=		generated:main
 
 SPKGS[standard]=	single


### PR DESCRIPTION
I didn't think I'd fix this game one more time, but at least now FPS limiter works properly at OpenBSD, the whole problem was OpenBSD is not tickless, OpenBSD allows to sleep for 10 milliseconds and more. All I did was just [removing code](https://github.com/OrangeGrayCyan/warsow/commit/58d690e920359857f984ad1112712c0d6a7b7d8a), now this game will never sleep and that's ok.