### PR TITLE
cyrus-sasl: add alternative download location ( via github )

### DIFF
--- a/bucket_51/cyrus-sasl/specification
+++ b/bucket_51/cyrus-sasl/specification
@@ -14,6 +14,7 @@ CONTACT=		nobody
 DOWNLOAD_GROUPS=	main
 SITES[main]=		http://cyrusimap.org/releases/
 			ftp://ftp.cyrusimap.org/cyrus-sasl/
+			https://github.com/cyrusimap/cyrus-sasl/releases/download/cyrus-sasl-${PORTVERSION}/
 DISTFILE[1]=		cyrus-sasl-${PORTVERSION}.tar.gz:main
 
 SPKGS[standard]=	complete primary docs


### PR DESCRIPTION

- fetching failed / timed out

```shell
--------------------------------------------------------------------------------
--  Phase: fetch
--------------------------------------------------------------------------------
===>  Fetching for cyrus-sasl-standard
=> cyrus-sasl-2.1.27.tar.gz doesn't seem to exist in /distfiles.
=> Attempting to fetch http://cyrusimap.org/releases/cyrus-sasl-2.1.27.tar.gz
http://cyrusimap.org/releases/cyrus-sasl-2.1.27.tar.gz: Not Found
=> Attempting to fetch ftp://ftp.cyrusimap.org/cyrus-sasl/cyrus-sasl-2.1.27.tar.gz
ftp://ftp.cyrusimap.org/cyrus-sasl/cyrus-sasl-2.1.27.tar.gz: Operation timed out
=> Attempting to fetch https://github.com/cyrusimap/cyrus-sasl/releases/download/cyrus-sasl-2.1.27/cyrus-sasl-2.1.27.tar.gz
cyrus-sasl-2.1.27.tar.gz                              4014 kB 1360 kBps    03s
```