### PR TITLE
sudo: configure without pam on NetBSD

### DIFF
--- a/bucket_83/sudo/specification
+++ b/bucket_83/sudo/specification
@@ -46,6 +46,7 @@ CONFIGURE_ARGS=		--sysconfdir={{PREFIX}}/etc
 			--disable-noargs-shell
 
 VAR_OPSYS[dragonfly]=	CONFIGURE_ARGS=--enable-hardening=no
+VAR_OPSYS[netbsd]=    CONFIGURE_ARGS=--without-pam
 
 post-patch:
 	${REINPLACE_CMD} -E '/install-(binaries|noexec):/,/^$$/ \


### PR DESCRIPTION
sudo fails to build on NetBSD due to issues with PAM. As a temporary fix, adding a configuration argument to build without PAM works. 