### PR TITLE
pcre: update download site

### DIFF
--- a/bucket_D1/pcre/specification
+++ b/bucket_D1/pcre/specification
@@ -15,7 +15,7 @@ HOMEPAGE=		http://www.pcre.org/
 CONTACT=		nobody
 
 DOWNLOAD_GROUPS=	main
-SITES[main]=		https://ftp.pcre.org/pub/pcre/
+SITES[main]=		https://sourceforge.net/projects/pcre/files/pcre/${PORTVERSION}
 DISTFILE[1]=		pcre-${PORTVERSION}.tar.bz2:main
 
 SPKGS[standard]=	complete static shared docs

--- a/bucket_D1/pcre/specification
+++ b/bucket_D1/pcre/specification
@@ -12,7 +12,7 @@ KEYWORDS=		devel textproc
 VARIANTS=		standard
 SDESC[standard]=	Perl Compatible Regular Expressions library
 HOMEPAGE=		http://www.pcre.org/
-CONTACT=		nobody
+CONTACT=		Todd_Martin[warfox@sdf.org]
 
 DOWNLOAD_GROUPS=	main
 SITES[main]=		https://sourceforge.net/projects/pcre/files/pcre/${PORTVERSION}


### PR DESCRIPTION
As per issue #230, pcre no longer maintains their FTP mirror for downloading package. To maintain pcre and not pcre2, must pull packages from their source forge site.

Fetch logs from `/var/ravenports/primary/logs/logs/pcre___standard.log` on NetBSD
```
--------------------------------------------------------------------------------
--  Phase: fetch
--------------------------------------------------------------------------------
===>  Fetching for pcre-standard
=> pcre-8.45.tar.bz2 doesn't seem to exist in /distfiles.
=> Attempting to fetch https://sourceforge.net/projects/pcre/files/pcre/8.45/pcre-8.45.tar.bz2
pcre-8.45.tar.bz2                                     1541 kB  304 kBps    05s
```