### PR TITLE
pcre: format properly for fetch phase

### DIFF
--- a/bucket_D1/pcre/specification
+++ b/bucket_D1/pcre/specification
@@ -15,7 +15,7 @@ HOMEPAGE=		http://www.pcre.org/
 CONTACT=		Todd_Martin[warfox@sdf.org]
 
 DOWNLOAD_GROUPS=	main
-SITES[main]=		https://sourceforge.net/projects/pcre/files/pcre/${PORTVERSION}
+SITES[main]=		https://sourceforge.net/projects/pcre/files/pcre/${PORTVERSION}/
 DISTFILE[1]=		pcre-${PORTVERSION}.tar.bz2:main
 
 SPKGS[standard]=	complete static shared docs


### PR DESCRIPTION
Left off a back slash on the end, otherwise ravenadm fails to fetch